### PR TITLE
Allow empty file extension for gene list

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,3 +49,6 @@ command:
 # will be permitted.
 file-types:
   - .txt
+  - .csv
+  - .tsv
+  - ""


### PR DESCRIPTION
In order to accept temporary result URLs, empty extensions must be allowed by the gene list handler. I also added .csv and .tsv (I thought I had done this earlier) as gene lists are valid single-column .tsv/.csv files.